### PR TITLE
fix for xcb

### DIFF
--- a/Tutorial - 0005/Window_xcb.cpp
+++ b/Tutorial - 0005/Window_xcb.cpp
@@ -74,11 +74,11 @@ void Window::_InitOSWindow()
 		XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y, coords );
 	xcb_flush( _xcb_connection );
 
-	xcb_generic_event_t *e;
+	/*xcb_generic_event_t *e;
 	while( ( e = xcb_wait_for_event( _xcb_connection ) ) ) {
 		if( ( e->response_type & ~0x80 ) == XCB_EXPOSE )
 			break;
-	}
+	}*/
 }
 
 /*
@@ -103,16 +103,18 @@ void Window::_DeInitOSWindow()
 void Window::_UpdateOSWindow()
 {
 	auto event = xcb_poll_for_event( _xcb_connection );
-	switch( event->response_type & ~0x80 )
-	case XCB_CLIENT_MESSAGE:
-		if( ( (xcb_client_message_event_t*)event )->data.data32[ 0 ] == _xcb_atom_window_reply->atom ) {
-			Close();
+	if( event != NULL ) {
+		switch( event->response_type & ~0x80 ) {
+		case XCB_CLIENT_MESSAGE:
+			if( ( (xcb_client_message_event_t*)event )->data.data32[ 0 ] == _xcb_atom_window_reply->atom ) {
+				Close();
+			}
+			break;
+		default:
+			break;
 		}
-		break;
-	default:
-		break;
+		free( event );
 	}
-	free( event );
 }
 
 #endif

--- a/Tutorial - 0006/Window_xcb.cpp
+++ b/Tutorial - 0006/Window_xcb.cpp
@@ -76,11 +76,11 @@ void Window::_InitOSWindow()
 		XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y, coords );
 	xcb_flush( _xcb_connection );
 
-	xcb_generic_event_t *e;
+	/*xcb_generic_event_t *e;
 	while( ( e = xcb_wait_for_event( _xcb_connection ) ) ) {
 		if( ( e->response_type & ~0x80 ) == XCB_EXPOSE )
 			break;
-	}
+	}*/
 }
 
 void Window::_DeInitOSWindow()
@@ -94,16 +94,18 @@ void Window::_DeInitOSWindow()
 void Window::_UpdateOSWindow()
 {
 	auto event = xcb_poll_for_event( _xcb_connection );
-	switch( event->response_type & ~0x80 )
-	case XCB_CLIENT_MESSAGE:
-		if( ( (xcb_client_message_event_t*)event )->data.data32[ 0 ] == _xcb_atom_window_reply->atom ) {
-			Close();
+	if( event != NULL ) {
+		switch( event->response_type & ~0x80 ) {
+		case XCB_CLIENT_MESSAGE:
+			if( ( (xcb_client_message_event_t*)event )->data.data32[ 0 ] == _xcb_atom_window_reply->atom ) {
+				Close();
+			}
+			break;
+		default:
+			break;
 		}
-		break;
-	default:
-		break;
+		free( event );
 	}
-	free( event );
 }
 
 void Window::_InitOSSurface()


### PR DESCRIPTION
The window created with XCB used to segfault because `xcb_poll_for_event` is non-blocking and returns `NULL` when no event is available. So, dereferencing `event` as `event->response_type` was crashing the app.
