### PR TITLE
Added GLFW build support with -D BUILD_GLFW

### DIFF
--- a/Tutorial - 0006/Platform.h
+++ b/Tutorial - 0006/Platform.h
@@ -6,13 +6,27 @@
 // Biggest missing right now is support for Android.
 // others like Xlib and so are also welcome additions.
 
+#include <stdint.h>
+#include <vector>
+
+extern void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions );
+
+// GLFW
+#if defined( BUILD_GLFW )
+// Define as a build option 
+#define VK_USE_PLATFORM_GLFW_KHR 1
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+#ifdef _WIN32 // for message box
+#include <windows.h>
+#endif 
+
 // WINDOWS
-#if defined( _WIN32 )
+#elif defined( _WIN32 )
 // this is always defined on windows platform
 
 #define VK_USE_PLATFORM_WIN32_KHR 1
-#define PLATFORM_SURFACE_EXTENSION_NAME VK_KHR_WIN32_SURFACE_EXTENSION_NAME
-#include <Windows.h>
+#include <windows.h>
 
 // LINUX ( Via XCB library )
 #elif defined( __linux )
@@ -22,7 +36,6 @@
 // xcb seems like a popular and well supported option on X11, until wayland and mir take over
 
 #define VK_USE_PLATFORM_XCB_KHR 1
-#define PLATFORM_SURFACE_EXTENSION_NAME VK_KHR_XCB_SURFACE_EXTENSION_NAME
 #include <xcb/xcb.h>
 
 #else

--- a/Tutorial - 0006/Renderer.cpp
+++ b/Tutorial - 0006/Renderer.cpp
@@ -77,7 +77,7 @@ const VkPhysicalDeviceProperties & Renderer::GetVulkanPhysicalDeviceProperties()
 void Renderer::_SetupLayersAndExtensions()
 {
 	_instance_extensions.push_back( VK_KHR_SURFACE_EXTENSION_NAME );
-	_instance_extensions.push_back( PLATFORM_SURFACE_EXTENSION_NAME );
+	AddRequiredPlatformInstanceExtensions( &_instance_extensions );
 }
 
 void Renderer::_InitInstance()

--- a/Tutorial - 0006/Tutorial - 0006.vcxproj
+++ b/Tutorial - 0006/Tutorial - 0006.vcxproj
@@ -137,6 +137,7 @@
     <ClCompile Include="Renderer.cpp" />
     <ClCompile Include="Shared.cpp" />
     <ClCompile Include="Window.cpp" />
+    <ClCompile Include="Window_glfw.cpp" />
     <ClCompile Include="Window_win32.cpp" />
     <ClCompile Include="Window_xcb.cpp" />
   </ItemGroup>

--- a/Tutorial - 0006/Tutorial - 0006.vcxproj.filters
+++ b/Tutorial - 0006/Tutorial - 0006.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="Window.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Window_glfw.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Window_win32.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Tutorial - 0006/Window.h
+++ b/Tutorial - 0006/Window.h
@@ -37,7 +37,9 @@ private:
 
 	bool								_window_should_run				= true;
 
-#if VK_USE_PLATFORM_WIN32_KHR
+#if VK_USE_PLATFORM_GLFW_KHR
+	GLFWwindow* _glfw_window = nullptr;
+#elif VK_USE_PLATFORM_WIN32_KHR
 	HINSTANCE							_win32_instance					= NULL;
 	HWND								_win32_window					= NULL;
 	std::string							_win32_class_name;

--- a/Tutorial - 0006/Window_glfw.cpp
+++ b/Tutorial - 0006/Window_glfw.cpp
@@ -1,0 +1,71 @@
+#include "BUILD_OPTIONS.h"
+#include "Platform.h"
+
+#include "Window.h"
+#include "Shared.h"
+#include "Renderer.h"
+
+#include <assert.h>
+#include <iostream>
+
+#if VK_USE_PLATFORM_GLFW_KHR
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	if ( glfwInit() == GLFW_FALSE ){
+		assert( 0 && "GLFW failed to initialize." );
+		return;
+	}
+	if ( glfwVulkanSupported() == GLFW_FALSE ) {
+		glfwTerminate();
+		assert ( 0 && "GLFW reported Vulkan is not supported." );
+		return;
+	}
+    uint32_t instance_extension_count = 0;
+	const char ** instance_extensions_buffer = glfwGetRequiredInstanceExtensions( &instance_extension_count );
+	for ( uint32_t i=0; i < instance_extension_count; i++ ){
+		instance_extensions->push_back( instance_extensions_buffer[i] );
+	}
+}
+
+void Window::_InitOSWindow()
+{	
+	if ( glfwInit() == GLFW_FALSE ) {
+		assert ( 0 && "GLFW failed to initialize." );
+		return;
+	}
+	if ( glfwVulkanSupported() == GLFW_FALSE ) {
+		glfwTerminate();
+		assert( 0 && "GLFW reported Vulkan is not supported." );
+		return;
+	}
+
+	glfwWindowHint( GLFW_CLIENT_API, GLFW_NO_API );
+	_glfw_window = glfwCreateWindow( _surface_size_x, _surface_size_y, _window_name.c_str(), nullptr, nullptr );
+	glfwGetFramebufferSize ( _glfw_window, (int*)&_surface_size_x, (int*)&_surface_size_y );
+
+}
+
+void Window::_DeInitOSWindow()
+{
+	glfwDestroyWindow( _glfw_window );	
+}
+
+void Window::_UpdateOSWindow()
+{
+	glfwPollEvents();
+
+	if ( glfwWindowShouldClose( _glfw_window ) ){
+		Close();
+	}
+}
+
+void Window::_InitOSSurface()
+{
+	if ( VK_SUCCESS != glfwCreateWindowSurface( _renderer->GetVulkanInstance(), _glfw_window, nullptr, &_surface ) ){
+		glfwTerminate();
+		assert ( 0 && "GLFW could not create the window surface." );
+		return;
+	}
+}
+
+#endif // VK_USE_PLATFORM_GLFW_KHR

--- a/Tutorial - 0006/Window_win32.cpp
+++ b/Tutorial - 0006/Window_win32.cpp
@@ -11,6 +11,10 @@
 
 #if VK_USE_PLATFORM_WIN32_KHR
 
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	instance_extensions->push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
+}
+
 // Microsoft Windows specific versions of window functions
 LRESULT CALLBACK WindowsEventHandler( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {

--- a/Tutorial - 0006/Window_xcb.cpp
+++ b/Tutorial - 0006/Window_xcb.cpp
@@ -11,6 +11,10 @@
 
 #if VK_USE_PLATFORM_XCB_KHR
 
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	    instance_extensions->push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
+}
+
 void Window::_InitOSWindow()
 {
 	// create connection to X11 server

--- a/Tutorial - 0007/Platform.h
+++ b/Tutorial - 0007/Platform.h
@@ -6,13 +6,27 @@
 // Biggest missing right now is support for Android.
 // others like Xlib and so are also welcome additions.
 
+#include <stdint.h>
+#include <vector>
+
+extern void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions );
+
+// GLFW
+#if defined( BUILD_GLFW )
+// Define as a build option 
+#define VK_USE_PLATFORM_GLFW_KHR 1
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+#ifdef _WIN32 // for message box
+#include <windows.h>
+#endif 
+
 // WINDOWS
-#if defined( _WIN32 )
+#elif defined( _WIN32 )
 // this is always defined on windows platform
 
 #define VK_USE_PLATFORM_WIN32_KHR 1
-#define PLATFORM_SURFACE_EXTENSION_NAME VK_KHR_WIN32_SURFACE_EXTENSION_NAME
-#include <Windows.h>
+#include <windows.h>
 
 // LINUX ( Via XCB library )
 #elif defined( __linux )
@@ -22,7 +36,6 @@
 // xcb seems like a popular and well supported option on X11, until wayland and mir take over
 
 #define VK_USE_PLATFORM_XCB_KHR 1
-#define PLATFORM_SURFACE_EXTENSION_NAME VK_KHR_XCB_SURFACE_EXTENSION_NAME
 #include <xcb/xcb.h>
 
 #else

--- a/Tutorial - 0007/Renderer.cpp
+++ b/Tutorial - 0007/Renderer.cpp
@@ -77,7 +77,7 @@ const VkPhysicalDeviceProperties & Renderer::GetVulkanPhysicalDeviceProperties()
 void Renderer::_SetupLayersAndExtensions()
 {
 	_instance_extensions.push_back( VK_KHR_SURFACE_EXTENSION_NAME );
-	_instance_extensions.push_back( PLATFORM_SURFACE_EXTENSION_NAME );
+	AddRequiredPlatformInstanceExtensions( &_instance_extensions );
 
 	_device_extensions.push_back( VK_KHR_SWAPCHAIN_EXTENSION_NAME );
 }

--- a/Tutorial - 0007/Tutorial - 0007.vcxproj
+++ b/Tutorial - 0007/Tutorial - 0007.vcxproj
@@ -137,6 +137,7 @@
     <ClCompile Include="Renderer.cpp" />
     <ClCompile Include="Shared.cpp" />
     <ClCompile Include="Window.cpp" />
+	<ClCompile Include="Window_glfw.cpp" />
     <ClCompile Include="Window_win32.cpp" />
     <ClCompile Include="Window_xcb.cpp" />
   </ItemGroup>

--- a/Tutorial - 0007/Tutorial - 0007.vcxproj.filters
+++ b/Tutorial - 0007/Tutorial - 0007.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="Window.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Window_glfw.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Window_win32.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Tutorial - 0007/Window.h
+++ b/Tutorial - 0007/Window.h
@@ -42,7 +42,9 @@ private:
 
 	bool								_window_should_run				= true;
 
-#if VK_USE_PLATFORM_WIN32_KHR
+#if VK_USE_PLATFORM_GLFW_KHR
+	GLFWwindow* _glfw_window = nullptr;
+#elif VK_USE_PLATFORM_WIN32_KHR
 	HINSTANCE							_win32_instance					= NULL;
 	HWND								_win32_window					= NULL;
 	std::string							_win32_class_name;

--- a/Tutorial - 0007/Window_glfw.cpp
+++ b/Tutorial - 0007/Window_glfw.cpp
@@ -1,0 +1,71 @@
+#include "BUILD_OPTIONS.h"
+#include "Platform.h"
+
+#include "Window.h"
+#include "Shared.h"
+#include "Renderer.h"
+
+#include <assert.h>
+#include <iostream>
+
+#if VK_USE_PLATFORM_GLFW_KHR
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	if ( glfwInit() == GLFW_FALSE ){
+		assert( 0 && "GLFW failed to initialize." );
+		return;
+	}
+	if ( glfwVulkanSupported() == GLFW_FALSE ) {
+		glfwTerminate();
+		assert ( 0 && "GLFW reported Vulkan is not supported." );
+		return;
+	}
+    uint32_t instance_extension_count = 0;
+	const char ** instance_extensions_buffer = glfwGetRequiredInstanceExtensions( &instance_extension_count );
+	for ( uint32_t i=0; i < instance_extension_count; i++ ){
+		instance_extensions->push_back( instance_extensions_buffer[i] );
+	}
+}
+
+void Window::_InitOSWindow()
+{	
+	if ( glfwInit() == GLFW_FALSE ) {
+		assert ( 0 && "GLFW failed to initialize." );
+		return;
+	}
+	if ( glfwVulkanSupported() == GLFW_FALSE ) {
+		glfwTerminate();
+		assert( 0 && "GLFW reported Vulkan is not supported." );
+		return;
+	}
+
+	glfwWindowHint( GLFW_CLIENT_API, GLFW_NO_API );
+	_glfw_window = glfwCreateWindow( _surface_size_x, _surface_size_y, _window_name.c_str(), nullptr, nullptr );
+	glfwGetFramebufferSize ( _glfw_window, (int*)&_surface_size_x, (int*)&_surface_size_y );
+
+}
+
+void Window::_DeInitOSWindow()
+{
+	glfwDestroyWindow( _glfw_window );	
+}
+
+void Window::_UpdateOSWindow()
+{
+	glfwPollEvents();
+
+	if ( glfwWindowShouldClose( _glfw_window ) ){
+		Close();
+	}
+}
+
+void Window::_InitOSSurface()
+{
+	if ( VK_SUCCESS != glfwCreateWindowSurface( _renderer->GetVulkanInstance(), _glfw_window, nullptr, &_surface ) ){
+		glfwTerminate();
+		assert ( 0 && "GLFW could not create the window surface." );
+		return;
+	}
+}
+
+#endif // VK_USE_PLATFORM_GLFW_KHR

--- a/Tutorial - 0007/Window_win32.cpp
+++ b/Tutorial - 0007/Window_win32.cpp
@@ -11,6 +11,10 @@
 
 #if VK_USE_PLATFORM_WIN32_KHR
 
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	instance_extensions->push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
+}
+
 // Microsoft Windows specific versions of window functions
 LRESULT CALLBACK WindowsEventHandler( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {

--- a/Tutorial - 0007/Window_xcb.cpp
+++ b/Tutorial - 0007/Window_xcb.cpp
@@ -11,6 +11,10 @@
 
 #if VK_USE_PLATFORM_XCB_KHR
 
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	    instance_extensions->push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
+}
+
 void Window::_InitOSWindow()
 {
 	// create connection to X11 server

--- a/Tutorial - 0008/Platform.cpp
+++ b/Tutorial - 0008/Platform.cpp
@@ -1,0 +1,26 @@
+#include "Platform.h"
+
+#if USE_FRAMEWORK_GLFW
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	uint32_t instance_extension_count = 0;
+	const char ** instance_extensions_buffer = glfwGetRequiredInstanceExtensions( &instance_extension_count );
+	for ( uint32_t i=0; i < instance_extension_count; i++ ){
+		instance_extensions->push_back( instance_extensions_buffer[i] );
+	}
+}
+
+#elif VK_USE_PLATFORM_WIN32_KHR
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	    instance_extensions->push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
+}
+
+#elif VK_USE_PLATFORM_XCB_KHR
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	        instance_extensions->push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
+}
+
+#endif
+

--- a/Tutorial - 0008/Platform.h
+++ b/Tutorial - 0008/Platform.h
@@ -9,24 +9,26 @@
 #include <stdint.h>
 #include <vector>
 
-extern void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions );
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions );
 
 // GLFW
 #if defined( BUILD_GLFW )
+
 // Define as a build option 
-#define VK_USE_PLATFORM_GLFW_KHR 1
+#define USE_FRAMEWORK_GLFW 1
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
-#ifdef _WIN32 // for message box
+// For Windows Message Box
+#if defined( _WIN32 ) 
 #include <windows.h>
 #endif 
 
 // WINDOWS
-#if defined( _WIN32 )
+#elif defined( _WIN32 )
 // this is always defined on windows platform
 
 #define VK_USE_PLATFORM_WIN32_KHR 1
-#include <Windows.h>
+#include <windows.h>
 
 // LINUX ( Via XCB library )
 #elif defined( __linux )

--- a/Tutorial - 0008/Platform.h
+++ b/Tutorial - 0008/Platform.h
@@ -6,12 +6,26 @@
 // Biggest missing right now is support for Android.
 // others like Xlib and so are also welcome additions.
 
+#include <stdint.h>
+#include <vector>
+
+extern void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions );
+
+// GLFW
+#if defined( BUILD_GLFW )
+// Define as a build option 
+#define VK_USE_PLATFORM_GLFW_KHR 1
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+#ifdef _WIN32 // for message box
+#include <windows.h>
+#endif 
+
 // WINDOWS
 #if defined( _WIN32 )
 // this is always defined on windows platform
 
 #define VK_USE_PLATFORM_WIN32_KHR 1
-#define PLATFORM_SURFACE_EXTENSION_NAME VK_KHR_WIN32_SURFACE_EXTENSION_NAME
 #include <Windows.h>
 
 // LINUX ( Via XCB library )
@@ -22,7 +36,6 @@
 // xcb seems like a popular and well supported option on X11, until wayland and mir take over
 
 #define VK_USE_PLATFORM_XCB_KHR 1
-#define PLATFORM_SURFACE_EXTENSION_NAME VK_KHR_XCB_SURFACE_EXTENSION_NAME
 #include <xcb/xcb.h>
 
 #else

--- a/Tutorial - 0008/Renderer.cpp
+++ b/Tutorial - 0008/Renderer.cpp
@@ -77,7 +77,7 @@ const VkPhysicalDeviceProperties & Renderer::GetVulkanPhysicalDeviceProperties()
 void Renderer::_SetupLayersAndExtensions()
 {
 	_instance_extensions.push_back( VK_KHR_SURFACE_EXTENSION_NAME );
-	_instance_extensions.push_back( PLATFORM_SURFACE_EXTENSION_NAME );
+	AddRequiredPlatformInstanceExtensions( &_instance_extensions );
 
 	_device_extensions.push_back( VK_KHR_SWAPCHAIN_EXTENSION_NAME );
 }

--- a/Tutorial - 0008/Renderer.cpp
+++ b/Tutorial - 0008/Renderer.cpp
@@ -14,6 +14,13 @@
 
 Renderer::Renderer()
 {
+#if USE_FRAMEWORK_GLFW
+	glfwInit();
+	if ( glfwVulkanSupported() == GLFW_FALSE ){
+		assert( 0 && " GLFW Failed to initialize with Vulkan.");
+		return;
+	}
+#endif
 	_SetupLayersAndExtensions();
 	_SetupDebug();
 	_InitInstance();
@@ -28,6 +35,9 @@ Renderer::~Renderer()
 	_DeInitDevice();
 	_DeInitDebug();
 	_DeInitInstance();
+#if USE_FRAMEWORK_GLFW
+	glfwTerminate();
+#endif
 }
 
 Window * Renderer::OpenWindow( uint32_t size_x, uint32_t size_y, std::string name )

--- a/Tutorial - 0008/Tutorial - 0008.vcxproj
+++ b/Tutorial - 0008/Tutorial - 0008.vcxproj
@@ -137,6 +137,7 @@
     <ClCompile Include="Renderer.cpp" />
     <ClCompile Include="Shared.cpp" />
     <ClCompile Include="Window.cpp" />
+	<ClCompile Include="Window_glfw.cpp" />
     <ClCompile Include="Window_win32.cpp" />
     <ClCompile Include="Window_xcb.cpp" />
   </ItemGroup>

--- a/Tutorial - 0008/Tutorial - 0008.vcxproj.filters
+++ b/Tutorial - 0008/Tutorial - 0008.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="Window.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Window_glfw.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Window_win32.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Tutorial - 0008/Window.h
+++ b/Tutorial - 0008/Window.h
@@ -49,7 +49,9 @@ private:
 
 	bool								_window_should_run				= true;
 
-#if VK_USE_PLATFORM_WIN32_KHR
+#if VK_USE_PLATFORM_GLFW_KHR
+	GLFWwindow* _glfw_window = nullptr;
+#elif VK_USE_PLATFORM_WIN32_KHR
 	HINSTANCE							_win32_instance					= NULL;
 	HWND								_win32_window					= NULL;
 	std::string							_win32_class_name;

--- a/Tutorial - 0008/Window_glfw.cpp
+++ b/Tutorial - 0008/Window_glfw.cpp
@@ -12,20 +12,9 @@
 
 void Window::_InitOSWindow()
 {	
-	if ( glfwInit() == GLFW_FALSE ) {
-		assert ( 0 && "GLFW failed to initialize." );
-		return;
-	}
-	if ( glfwVulkanSupported() == GLFW_FALSE ) {
-		glfwTerminate();
-		assert( 0 && "GLFW reported Vulkan is not supported." );
-		return;
-	}
-
 	glfwWindowHint( GLFW_CLIENT_API, GLFW_NO_API );
 	_glfw_window = glfwCreateWindow( _surface_size_x, _surface_size_y, _window_name.c_str(), nullptr, nullptr );
 	glfwGetFramebufferSize ( _glfw_window, (int*)&_surface_size_x, (int*)&_surface_size_y );
-
 }
 
 void Window::_DeInitOSWindow()

--- a/Tutorial - 0008/Window_glfw.cpp
+++ b/Tutorial - 0008/Window_glfw.cpp
@@ -1,0 +1,71 @@
+#include "BUILD_OPTIONS.h"
+#include "Platform.h"
+
+#include "Window.h"
+#include "Shared.h"
+#include "Renderer.h"
+
+#include <assert.h>
+#include <iostream>
+
+#if VK_USE_PLATFORM_GLFW_KHR
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	if ( glfwInit() == GLFW_FALSE ){
+		assert( 0 && "GLFW failed to initialize." );
+		return;
+	}
+	if ( glfwVulkanSupported() == GLFW_FALSE ) {
+		glfwTerminate();
+		assert ( 0 && "GLFW reported Vulkan is not supported." );
+		return;
+	}
+    uint32_t instance_extension_count = 0;
+	const char ** instance_extensions_buffer = glfwGetRequiredInstanceExtensions( &instance_extension_count );
+	for ( uint32_t i=0; i < instance_extension_count; i++ ){
+		instance_extensions->push_back( instance_extensions_buffer[i] );
+	}
+}
+
+void Window::_InitOSWindow()
+{	
+	if ( glfwInit() == GLFW_FALSE ) {
+		assert ( 0 && "GLFW failed to initialize." );
+		return;
+	}
+	if ( glfwVulkanSupported() == GLFW_FALSE ) {
+		glfwTerminate();
+		assert( 0 && "GLFW reported Vulkan is not supported." );
+		return;
+	}
+
+	glfwWindowHint( GLFW_CLIENT_API, GLFW_NO_API );
+	_glfw_window = glfwCreateWindow( _surface_size_x, _surface_size_y, _window_name.c_str(), nullptr, nullptr );
+	glfwGetFramebufferSize ( _glfw_window, (int*)&_surface_size_x, (int*)&_surface_size_y );
+
+}
+
+void Window::_DeInitOSWindow()
+{
+	glfwDestroyWindow( _glfw_window );	
+}
+
+void Window::_UpdateOSWindow()
+{
+	glfwPollEvents();
+
+	if ( glfwWindowShouldClose( _glfw_window ) ){
+		Close();
+	}
+}
+
+void Window::_InitOSSurface()
+{
+	if ( VK_SUCCESS != glfwCreateWindowSurface( _renderer->GetVulkanInstance(), _glfw_window, nullptr, &_surface ) ){
+		glfwTerminate();
+		assert ( 0 && "GLFW could not create the window surface." );
+		return;
+	}
+}
+
+#endif // VK_USE_PLATFORM_GLFW_KHR

--- a/Tutorial - 0008/Window_glfw.cpp
+++ b/Tutorial - 0008/Window_glfw.cpp
@@ -8,24 +8,7 @@
 #include <assert.h>
 #include <iostream>
 
-#if VK_USE_PLATFORM_GLFW_KHR
-
-void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
-	if ( glfwInit() == GLFW_FALSE ){
-		assert( 0 && "GLFW failed to initialize." );
-		return;
-	}
-	if ( glfwVulkanSupported() == GLFW_FALSE ) {
-		glfwTerminate();
-		assert ( 0 && "GLFW reported Vulkan is not supported." );
-		return;
-	}
-    uint32_t instance_extension_count = 0;
-	const char ** instance_extensions_buffer = glfwGetRequiredInstanceExtensions( &instance_extension_count );
-	for ( uint32_t i=0; i < instance_extension_count; i++ ){
-		instance_extensions->push_back( instance_extensions_buffer[i] );
-	}
-}
+#if USE_FRAMEWORK_GLFW
 
 void Window::_InitOSWindow()
 {	
@@ -68,4 +51,4 @@ void Window::_InitOSSurface()
 	}
 }
 
-#endif // VK_USE_PLATFORM_GLFW_KHR
+#endif // USE_FRAMEWORK_GLFW

--- a/Tutorial - 0008/Window_win32.cpp
+++ b/Tutorial - 0008/Window_win32.cpp
@@ -11,6 +11,10 @@
 
 #if VK_USE_PLATFORM_WIN32_KHR
 
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	instance_extensions->push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
+}
+
 // Microsoft Windows specific versions of window functions
 LRESULT CALLBACK WindowsEventHandler( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {

--- a/Tutorial - 0008/Window_win32.cpp
+++ b/Tutorial - 0008/Window_win32.cpp
@@ -11,10 +11,6 @@
 
 #if VK_USE_PLATFORM_WIN32_KHR
 
-void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
-	instance_extensions->push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
-}
-
 // Microsoft Windows specific versions of window functions
 LRESULT CALLBACK WindowsEventHandler( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {

--- a/Tutorial - 0008/Window_xcb.cpp
+++ b/Tutorial - 0008/Window_xcb.cpp
@@ -11,10 +11,6 @@
 
 #if VK_USE_PLATFORM_XCB_KHR
 
-void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
-	    instance_extensions->push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
-}
-
 void Window::_InitOSWindow()
 {
 	// create connection to X11 server

--- a/Tutorial - 0008/Window_xcb.cpp
+++ b/Tutorial - 0008/Window_xcb.cpp
@@ -11,6 +11,10 @@
 
 #if VK_USE_PLATFORM_XCB_KHR
 
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	    instance_extensions->push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
+}
+
 void Window::_InitOSWindow()
 {
 	// create connection to X11 server


### PR DESCRIPTION
Pretty simple, if you define BUILD_GLFW when compiling it should build with GLFW now instead for tut 6,7,8 and beyond. 

The only real change I made was changing the PLATFORM_SURFACE_EXTENSION_NAME solution to a function call defined in each platform specific file.

Other than that added a Window_glfw.cpp file and made the necessary changes in Window.h and Platform.h.

One other thing to note is I changed the MSVC files by hand because I didn't have it installed so you may just want to double check I didn't mess it up. Also I changed #include <Windows.h> to #include <windows.h> because when I am cross compiling on Linux it is necessary. 

If you want to make any changes be my guest, just thought GLFW support would be nice now that it shouldn't be any work to maintain.

Thanks. 
