### PR TITLE
Code overhaul + GLFW

### DIFF
--- a/Tutorial - 0003/Renderer.cpp
+++ b/Tutorial - 0003/Renderer.cpp
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #include "Renderer.h"
 #include "Shared.h"
 
@@ -9,7 +20,7 @@
 #include <sstream>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 Renderer::Renderer()
@@ -116,8 +127,8 @@ void Renderer::_InitDevice()
 	device_create_info.sType					= VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 	device_create_info.queueCreateInfoCount		= 1;
 	device_create_info.pQueueCreateInfos		= &device_queue_create_info;
-	device_create_info.enabledLayerCount		= _device_layers.size();
-	device_create_info.ppEnabledLayerNames		= _device_layers.data();
+//	device_create_info.enabledLayerCount		= _device_layers.size();				// depricated
+//	device_create_info.ppEnabledLayerNames		= _device_layers.data();				// depricated
 	device_create_info.enabledExtensionCount	= _device_extensions.size();
 	device_create_info.ppEnabledExtensionNames	= _device_extensions.data();
 
@@ -196,7 +207,7 @@ void Renderer::_SetupDebug()
 	*/
 	_instance_extensions.push_back( VK_EXT_DEBUG_REPORT_EXTENSION_NAME );
 
-	_device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );
+//	_device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );				// depricated
 	/*
 //	_device_layers.push_back( "VK_LAYER_LUNARG_threading" );
 	_device_layers.push_back( "VK_LAYER_GOOGLE_threading" );

--- a/Tutorial - 0003/Renderer.h
+++ b/Tutorial - 0003/Renderer.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include <vulkan/vulkan.h>
@@ -30,7 +41,7 @@ public:
 
 	std::vector<const char*>	_instance_layers;
 	std::vector<const char*>	_instance_extensions;
-	std::vector<const char*>	_device_layers;
+//	std::vector<const char*>	_device_layers;				// depricated
 	std::vector<const char*>	_device_extensions;
 
 	VkDebugReportCallbackEXT	_debug_report				= nullptr;

--- a/Tutorial - 0003/Shared.cpp
+++ b/Tutorial - 0003/Shared.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "Shared.h"
 

--- a/Tutorial - 0003/Shared.h
+++ b/Tutorial - 0003/Shared.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include <iostream>

--- a/Tutorial - 0003/Tutorial - 0003.vcxproj
+++ b/Tutorial - 0003/Tutorial - 0003.vcxproj
@@ -69,20 +69,20 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Tutorial - 0003/main.cpp
+++ b/Tutorial - 0003/main.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "Renderer.h"
 

--- a/Tutorial - 0004/Renderer.cpp
+++ b/Tutorial - 0004/Renderer.cpp
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #include "Renderer.h"
 #include "Shared.h"
 
@@ -9,7 +20,7 @@
 #include <sstream>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 Renderer::Renderer()
@@ -116,8 +127,8 @@ void Renderer::_InitDevice()
 	device_create_info.sType					= VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 	device_create_info.queueCreateInfoCount		= 1;
 	device_create_info.pQueueCreateInfos		= &device_queue_create_info;
-	device_create_info.enabledLayerCount		= _device_layers.size();
-	device_create_info.ppEnabledLayerNames		= _device_layers.data();
+//	device_create_info.enabledLayerCount		= _device_layers.size();				// depricated
+//	device_create_info.ppEnabledLayerNames		= _device_layers.data();				// depricated
 	device_create_info.enabledExtensionCount	= _device_extensions.size();
 	device_create_info.ppEnabledExtensionNames	= _device_extensions.data();
 
@@ -198,7 +209,7 @@ void Renderer::_SetupDebug()
 	*/
 	_instance_extensions.push_back( VK_EXT_DEBUG_REPORT_EXTENSION_NAME );
 
-	_device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );
+//	_device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );				// depricated
 	/*
 //	_device_layers.push_back( "VK_LAYER_LUNARG_threading" );
 	_device_layers.push_back( "VK_LAYER_GOOGLE_threading" );

--- a/Tutorial - 0004/Renderer.h
+++ b/Tutorial - 0004/Renderer.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include <vulkan/vulkan.h>
@@ -31,7 +42,7 @@ public:
 
 	std::vector<const char*>	_instance_layers;
 	std::vector<const char*>	_instance_extensions;
-	std::vector<const char*>	_device_layers;
+//	std::vector<const char*>	_device_layers;				// depricated
 	std::vector<const char*>	_device_extensions;
 
 	VkDebugReportCallbackEXT	_debug_report				= VK_NULL_HANDLE;

--- a/Tutorial - 0004/Shared.cpp
+++ b/Tutorial - 0004/Shared.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "Shared.h"
 

--- a/Tutorial - 0004/Shared.h
+++ b/Tutorial - 0004/Shared.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include <iostream>

--- a/Tutorial - 0004/Tutorial - 0004.vcxproj
+++ b/Tutorial - 0004/Tutorial - 0004.vcxproj
@@ -69,20 +69,20 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Tutorial - 0004/main.cpp
+++ b/Tutorial - 0004/main.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "Renderer.h"
 

--- a/Tutorial - 0005 - GLFW Example/Tutorial - 0005 - GLFW Example.vcxproj
+++ b/Tutorial - 0005 - GLFW Example/Tutorial - 0005 - GLFW Example.vcxproj
@@ -69,20 +69,20 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Tutorial - 0005 - GLFW Example/main.cpp
+++ b/Tutorial - 0005 - GLFW Example/main.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 /*
 This example is using GLFW for window creation and surfaces Using Vulkan API.
@@ -8,11 +18,6 @@ with the OS specific stuff, this code should run on all OSes without modificatio
 Before running though, you will need to direct your include and library
 directories to your GLFW 3.2 locations in project settings.
 You will need GLFW version 3.2 or newer.
-
-Provided as-is without any quarantee that it'll work
-but I will likely fix any errors reported.
-
-Code licence: CC0
 */
 
 // if you have a non-standard path to vulkan, you need to include the vulkan header before GLFW,
@@ -31,14 +36,14 @@ int main()
 {
 	// regular instance and device layers and extensions
 	std::vector<const char*> instance_layers;
-	std::vector<const char*> device_layers;
+//	std::vector<const char*> device_layers;					// depricated
 	std::vector<const char*> instance_extensions;
 	std::vector<const char*> device_extensions;
 
 	// if using debugging, push back debug layers and extensions
 	instance_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );
 	instance_extensions.push_back( VK_EXT_DEBUG_REPORT_EXTENSION_NAME );
-	device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );
+//	device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );			// depricated
 
 	// push back extensions and layers you need
 	// We'll need the swapchain for sure if we want to display anything
@@ -122,8 +127,8 @@ int main()
 	device_create_info.sType						= VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 	device_create_info.queueCreateInfoCount			= 1;
 	device_create_info.pQueueCreateInfos			= &queue_create_info;
-	device_create_info.enabledLayerCount			= device_layers.size();
-	device_create_info.ppEnabledLayerNames			= device_layers.data();
+//	device_create_info.enabledLayerCount			= device_layers.size();				// depricated
+//	device_create_info.ppEnabledLayerNames			= device_layers.data();				// depricated
 	device_create_info.enabledLayerCount			= device_extensions.size();
 	device_create_info.ppEnabledExtensionNames		= device_extensions.data();
 

--- a/Tutorial - 0005/BUILD_OPTIONS.h
+++ b/Tutorial - 0005/BUILD_OPTIONS.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #define BUILD_ENABLE_VULKAN_DEBUG								1

--- a/Tutorial - 0005/Platform.h
+++ b/Tutorial - 0005/Platform.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 // Contact me if you're interested about adding platform
@@ -11,7 +22,7 @@
 // this is always defined on windows platform
 
 #define VK_USE_PLATFORM_WIN32_KHR 1
-#include <Windows.h>
+#include <windows.h>
 
 // LINUX ( Via XCB library )
 #elif defined( __linux )

--- a/Tutorial - 0005/Renderer.cpp
+++ b/Tutorial - 0005/Renderer.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Platform.h"
@@ -109,8 +119,8 @@ void Renderer::_InitDevice()
 	device_create_info.sType					= VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 	device_create_info.queueCreateInfoCount		= 1;
 	device_create_info.pQueueCreateInfos		= &device_queue_create_info;
-	device_create_info.enabledLayerCount		= _device_layers.size();
-	device_create_info.ppEnabledLayerNames		= _device_layers.data();
+//	device_create_info.enabledLayerCount		= _device_layers.size();				// depricated
+//	device_create_info.ppEnabledLayerNames		= _device_layers.data();				// depricated
 	device_create_info.enabledExtensionCount	= _device_extensions.size();
 	device_create_info.ppEnabledExtensionNames	= _device_extensions.data();
 
@@ -193,7 +203,7 @@ void Renderer::_SetupDebug()
 	*/
 	_instance_extensions.push_back( VK_EXT_DEBUG_REPORT_EXTENSION_NAME );
 
-	_device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );
+//	_device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );				// depricated
 	/*
 //	_device_layers.push_back( "VK_LAYER_LUNARG_threading" );
 	_device_layers.push_back( "VK_LAYER_GOOGLE_threading" );

--- a/Tutorial - 0005/Renderer.h
+++ b/Tutorial - 0005/Renderer.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include "Platform.h"
@@ -40,7 +51,7 @@ private:
 
 	std::vector<const char*>	_instance_layers;
 	std::vector<const char*>	_instance_extensions;
-	std::vector<const char*>	_device_layers;
+//	std::vector<const char*>	_device_layers;				// depricated
 	std::vector<const char*>	_device_extensions;
 
 	VkDebugReportCallbackEXT	_debug_report				= VK_NULL_HANDLE;

--- a/Tutorial - 0005/Shared.cpp
+++ b/Tutorial - 0005/Shared.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Shared.h"

--- a/Tutorial - 0005/Shared.h
+++ b/Tutorial - 0005/Shared.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include "Platform.h"

--- a/Tutorial - 0005/Tutorial - 0005.vcxproj
+++ b/Tutorial - 0005/Tutorial - 0005.vcxproj
@@ -69,20 +69,20 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Tutorial - 0005/Window.cpp
+++ b/Tutorial - 0005/Window.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "Window.h"
 

--- a/Tutorial - 0005/Window.h
+++ b/Tutorial - 0005/Window.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include "Platform.h"

--- a/Tutorial - 0005/Window_win32.cpp
+++ b/Tutorial - 0005/Window_win32.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Platform.h"

--- a/Tutorial - 0005/Window_xcb.cpp
+++ b/Tutorial - 0005/Window_xcb.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Platform.h"

--- a/Tutorial - 0005/main.cpp
+++ b/Tutorial - 0005/main.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "Renderer.h"
 

--- a/Tutorial - 0006/BUILD_OPTIONS.h
+++ b/Tutorial - 0006/BUILD_OPTIONS.h
@@ -1,4 +1,21 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #define BUILD_ENABLE_VULKAN_DEBUG								1
 #define BUILD_ENABLE_VULKAN_RUNTIME_DEBUG						1
+
+// To use GLFW, make sure that it's available in the include directories
+// along with library directories. You will also need to add
+// GLFWs "*.lib" file into the project, this task is up to you.
+// GLFW 3.2 is required.
+#define BUILD_USE_GLFW											0

--- a/Tutorial - 0006/Platform.cpp
+++ b/Tutorial - 0006/Platform.cpp
@@ -1,0 +1,72 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Teagan Chouinard (GLFW)
+Contributors:
+Niko Kauppi (Code maintenance)
+----------------------------------------------------- */
+
+#include "Platform.h"
+
+#include <assert.h>
+
+#if USE_FRAMEWORK_GLFW
+
+void InitPlatform()
+{
+	glfwInit();
+	if( glfwVulkanSupported() == GLFW_FALSE ) {
+		assert( 0 && " GLFW Failed to initialize with Vulkan." );
+		return;
+	}
+}
+
+void DeInitPlatform()
+{
+	glfwTerminate();
+}
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions )
+{
+	uint32_t instance_extension_count = 0;
+	const char ** instance_extensions_buffer = glfwGetRequiredInstanceExtensions( &instance_extension_count );
+	for( uint32_t i=0; i < instance_extension_count; i++ ) {
+		instance_extensions->push_back( instance_extensions_buffer[ i ] );
+	}
+}
+
+#elif VK_USE_PLATFORM_WIN32_KHR
+
+void InitPlatform()
+{
+}
+
+void DeInitPlatform()
+{
+}
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions )
+{
+	instance_extensions->push_back( VK_KHR_WIN32_SURFACE_EXTENSION_NAME );
+}
+
+#elif VK_USE_PLATFORM_XCB_KHR
+
+void InitPlatform()
+{
+}
+
+void DeInitPlatform()
+{
+}
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions )
+{
+	instance_extensions->push_back( VK_KHR_XCB_SURFACE_EXTENSION_NAME );
+}
+
+#endif

--- a/Tutorial - 0006/Platform.h
+++ b/Tutorial - 0006/Platform.h
@@ -1,3 +1,15 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+Teagan Chouinard (GLFW)
+----------------------------------------------------- */
+
 #pragma once
 
 // Contact me if you're interested about adding platform
@@ -6,13 +18,33 @@
 // Biggest missing right now is support for Android.
 // others like Xlib and so are also welcome additions.
 
-// WINDOWS
+#include "BUILD_OPTIONS.h"
+#include <stdint.h>
+#include <vector>
+
+void InitPlatform();
+void DeInitPlatform();
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions );
+
+// GLFW
+#if BUILD_USE_GLFW
+
+// Define as a build option 
+#define USE_FRAMEWORK_GLFW 1
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+// For Windows Message Box
 #if defined( _WIN32 )
+#undef APIENTRY
+#include <windows.h>
+#endif 
+
+// WINDOWS
+#elif defined( _WIN32 )
 // this is always defined on windows platform
 
 #define VK_USE_PLATFORM_WIN32_KHR 1
-#define PLATFORM_SURFACE_EXTENSION_NAME VK_KHR_WIN32_SURFACE_EXTENSION_NAME
-#include <Windows.h>
+#include <windows.h>
 
 // LINUX ( Via XCB library )
 #elif defined( __linux )
@@ -22,7 +54,6 @@
 // xcb seems like a popular and well supported option on X11, until wayland and mir take over
 
 #define VK_USE_PLATFORM_XCB_KHR 1
-#define PLATFORM_SURFACE_EXTENSION_NAME VK_KHR_XCB_SURFACE_EXTENSION_NAME
 #include <xcb/xcb.h>
 
 #else

--- a/Tutorial - 0006/Renderer.cpp
+++ b/Tutorial - 0006/Renderer.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Platform.h"
@@ -14,6 +24,7 @@
 
 Renderer::Renderer()
 {
+	InitPlatform();
 	_SetupLayersAndExtensions();
 	_SetupDebug();
 	_InitInstance();
@@ -28,6 +39,7 @@ Renderer::~Renderer()
 	_DeInitDevice();
 	_DeInitDebug();
 	_DeInitInstance();
+	DeInitPlatform();
 }
 
 Window * Renderer::OpenWindow( uint32_t size_x, uint32_t size_y, std::string name )
@@ -77,7 +89,7 @@ const VkPhysicalDeviceProperties & Renderer::GetVulkanPhysicalDeviceProperties()
 void Renderer::_SetupLayersAndExtensions()
 {
 	_instance_extensions.push_back( VK_KHR_SURFACE_EXTENSION_NAME );
-	_instance_extensions.push_back( PLATFORM_SURFACE_EXTENSION_NAME );
+	AddRequiredPlatformInstanceExtensions( &_instance_extensions );
 }
 
 void Renderer::_InitInstance()
@@ -146,8 +158,8 @@ void Renderer::_InitDevice()
 	device_create_info.sType					= VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 	device_create_info.queueCreateInfoCount		= 1;
 	device_create_info.pQueueCreateInfos		= &device_queue_create_info;
-	device_create_info.enabledLayerCount		= _device_layers.size();
-	device_create_info.ppEnabledLayerNames		= _device_layers.data();
+//	device_create_info.enabledLayerCount		= _device_layers.size();				// depricated
+//	device_create_info.ppEnabledLayerNames		= _device_layers.data();				// depricated
 	device_create_info.enabledExtensionCount	= _device_extensions.size();
 	device_create_info.ppEnabledExtensionNames	= _device_extensions.data();
 
@@ -230,7 +242,7 @@ void Renderer::_SetupDebug()
 	*/
 	_instance_extensions.push_back( VK_EXT_DEBUG_REPORT_EXTENSION_NAME );
 
-	_device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );
+//	_device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );				// depricated
 	/*
 //	_device_layers.push_back( "VK_LAYER_LUNARG_threading" );
 	_device_layers.push_back( "VK_LAYER_GOOGLE_threading" );

--- a/Tutorial - 0006/Renderer.h
+++ b/Tutorial - 0006/Renderer.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include "Platform.h"
@@ -49,7 +60,7 @@ private:
 
 	std::vector<const char*>				_instance_layers;
 	std::vector<const char*>				_instance_extensions;
-	std::vector<const char*>				_device_layers;
+//	std::vector<const char*>				_device_layers;					// depricated
 	std::vector<const char*>				_device_extensions;
 
 	VkDebugReportCallbackEXT				_debug_report					= VK_NULL_HANDLE;

--- a/Tutorial - 0006/Shared.cpp
+++ b/Tutorial - 0006/Shared.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Shared.h"

--- a/Tutorial - 0006/Shared.h
+++ b/Tutorial - 0006/Shared.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include "Platform.h"

--- a/Tutorial - 0006/Tutorial - 0006.vcxproj
+++ b/Tutorial - 0006/Tutorial - 0006.vcxproj
@@ -69,20 +69,20 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -134,9 +134,11 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="Platform.cpp" />
     <ClCompile Include="Renderer.cpp" />
     <ClCompile Include="Shared.cpp" />
     <ClCompile Include="Window.cpp" />
+    <ClCompile Include="Window_glfw.cpp" />
     <ClCompile Include="Window_win32.cpp" />
     <ClCompile Include="Window_xcb.cpp" />
   </ItemGroup>

--- a/Tutorial - 0006/Tutorial - 0006.vcxproj.filters
+++ b/Tutorial - 0006/Tutorial - 0006.vcxproj.filters
@@ -27,10 +27,16 @@
     <ClCompile Include="Window.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Window_glfw.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Window_win32.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Window_xcb.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Platform.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Tutorial - 0006/Window.cpp
+++ b/Tutorial - 0006/Window.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "Window.h"
 #include "Renderer.h"

--- a/Tutorial - 0006/Window.h
+++ b/Tutorial - 0006/Window.h
@@ -1,3 +1,15 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+Teagan Chouinard (GLFW)
+----------------------------------------------------- */
+
 #pragma once
 
 #include "Platform.h"
@@ -37,7 +49,9 @@ private:
 
 	bool								_window_should_run				= true;
 
-#if VK_USE_PLATFORM_WIN32_KHR
+#if USE_FRAMEWORK_GLFW
+	GLFWwindow						*	_glfw_window					= nullptr;
+#elif VK_USE_PLATFORM_WIN32_KHR
 	HINSTANCE							_win32_instance					= NULL;
 	HWND								_win32_window					= NULL;
 	std::string							_win32_class_name;

--- a/Tutorial - 0006/Window_glfw.cpp
+++ b/Tutorial - 0006/Window_glfw.cpp
@@ -1,0 +1,56 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Teagan Chouinard (GLFW)
+Contributors:
+Niko Kauppi (Code maintenance)
+----------------------------------------------------- */
+
+#include "BUILD_OPTIONS.h"
+#include "Platform.h"
+
+#include "Window.h"
+#include "Shared.h"
+#include "Renderer.h"
+
+#include <assert.h>
+#include <iostream>
+
+#if USE_FRAMEWORK_GLFW
+
+void Window::_InitOSWindow()
+{
+	glfwWindowHint( GLFW_CLIENT_API, GLFW_NO_API );
+	_glfw_window = glfwCreateWindow( _surface_size_x, _surface_size_y, _window_name.c_str(), nullptr, nullptr );
+	glfwGetFramebufferSize( _glfw_window, (int*)&_surface_size_x, (int*)&_surface_size_y );
+}
+
+void Window::_DeInitOSWindow()
+{
+	glfwDestroyWindow( _glfw_window );
+}
+
+void Window::_UpdateOSWindow()
+{
+	glfwPollEvents();
+
+	if( glfwWindowShouldClose( _glfw_window ) ) {
+		Close();
+	}
+}
+
+void Window::_InitOSSurface()
+{
+	if( VK_SUCCESS != glfwCreateWindowSurface( _renderer->GetVulkanInstance(), _glfw_window, nullptr, &_surface ) ) {
+		glfwTerminate();
+		assert( 0 && "GLFW could not create the window surface." );
+		return;
+	}
+}
+
+#endif // USE_FRAMEWORK_GLFW
+

--- a/Tutorial - 0006/Window_win32.cpp
+++ b/Tutorial - 0006/Window_win32.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Platform.h"

--- a/Tutorial - 0006/Window_xcb.cpp
+++ b/Tutorial - 0006/Window_xcb.cpp
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+hodasemi (XCB validation)
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Platform.h"

--- a/Tutorial - 0006/main.cpp
+++ b/Tutorial - 0006/main.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "Renderer.h"
 

--- a/Tutorial - 0007/BUILD_OPTIONS.h
+++ b/Tutorial - 0007/BUILD_OPTIONS.h
@@ -1,4 +1,21 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #define BUILD_ENABLE_VULKAN_DEBUG								1
 #define BUILD_ENABLE_VULKAN_RUNTIME_DEBUG						1
+
+// To use GLFW, make sure that it's available in the include directories
+// along with library directories. You will also need to add
+// GLFWs "*.lib" file into the project, this task is up to you.
+// GLFW 3.2 is required.
+#define BUILD_USE_GLFW											0

--- a/Tutorial - 0007/Platform.cpp
+++ b/Tutorial - 0007/Platform.cpp
@@ -1,0 +1,72 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Teagan Chouinard (GLFW)
+Contributors:
+Niko Kauppi (Code maintenance)
+----------------------------------------------------- */
+
+#include "Platform.h"
+
+#include <assert.h>
+
+#if USE_FRAMEWORK_GLFW
+
+void InitPlatform()
+{
+	glfwInit();
+	if( glfwVulkanSupported() == GLFW_FALSE ) {
+		assert( 0 && " GLFW Failed to initialize with Vulkan." );
+		return;
+	}
+}
+
+void DeInitPlatform()
+{
+	glfwTerminate();
+}
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions )
+{
+	uint32_t instance_extension_count = 0;
+	const char ** instance_extensions_buffer = glfwGetRequiredInstanceExtensions( &instance_extension_count );
+	for( uint32_t i=0; i < instance_extension_count; i++ ) {
+		instance_extensions->push_back( instance_extensions_buffer[ i ] );
+	}
+}
+
+#elif VK_USE_PLATFORM_WIN32_KHR
+
+void InitPlatform()
+{
+}
+
+void DeInitPlatform()
+{
+}
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions )
+{
+	instance_extensions->push_back( VK_KHR_WIN32_SURFACE_EXTENSION_NAME );
+}
+
+#elif VK_USE_PLATFORM_XCB_KHR
+
+void InitPlatform()
+{
+}
+
+void DeInitPlatform()
+{
+}
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions )
+{
+	instance_extensions->push_back( VK_KHR_XCB_SURFACE_EXTENSION_NAME );
+}
+
+#endif

--- a/Tutorial - 0007/Platform.h
+++ b/Tutorial - 0007/Platform.h
@@ -1,3 +1,15 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+Teagan Chouinard (GLFW)
+----------------------------------------------------- */
+
 #pragma once
 
 // Contact me if you're interested about adding platform
@@ -6,13 +18,33 @@
 // Biggest missing right now is support for Android.
 // others like Xlib and so are also welcome additions.
 
-// WINDOWS
+#include "BUILD_OPTIONS.h"
+#include <stdint.h>
+#include <vector>
+
+void InitPlatform();
+void DeInitPlatform();
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions );
+
+// GLFW
+#if BUILD_USE_GLFW
+
+// Define as a build option 
+#define USE_FRAMEWORK_GLFW 1
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+// For Windows Message Box
 #if defined( _WIN32 )
+#undef APIENTRY
+#include <windows.h>
+#endif 
+
+// WINDOWS
+#elif defined( _WIN32 )
 // this is always defined on windows platform
 
 #define VK_USE_PLATFORM_WIN32_KHR 1
-#define PLATFORM_SURFACE_EXTENSION_NAME VK_KHR_WIN32_SURFACE_EXTENSION_NAME
-#include <Windows.h>
+#include <windows.h>
 
 // LINUX ( Via XCB library )
 #elif defined( __linux )
@@ -22,7 +54,6 @@
 // xcb seems like a popular and well supported option on X11, until wayland and mir take over
 
 #define VK_USE_PLATFORM_XCB_KHR 1
-#define PLATFORM_SURFACE_EXTENSION_NAME VK_KHR_XCB_SURFACE_EXTENSION_NAME
 #include <xcb/xcb.h>
 
 #else

--- a/Tutorial - 0007/Renderer.cpp
+++ b/Tutorial - 0007/Renderer.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Platform.h"
@@ -14,6 +24,7 @@
 
 Renderer::Renderer()
 {
+	InitPlatform();
 	_SetupLayersAndExtensions();
 	_SetupDebug();
 	_InitInstance();
@@ -28,6 +39,7 @@ Renderer::~Renderer()
 	_DeInitDevice();
 	_DeInitDebug();
 	_DeInitInstance();
+	DeInitPlatform();
 }
 
 Window * Renderer::OpenWindow( uint32_t size_x, uint32_t size_y, std::string name )
@@ -77,7 +89,7 @@ const VkPhysicalDeviceProperties & Renderer::GetVulkanPhysicalDeviceProperties()
 void Renderer::_SetupLayersAndExtensions()
 {
 	_instance_extensions.push_back( VK_KHR_SURFACE_EXTENSION_NAME );
-	_instance_extensions.push_back( PLATFORM_SURFACE_EXTENSION_NAME );
+	AddRequiredPlatformInstanceExtensions( &_instance_extensions );
 
 	_device_extensions.push_back( VK_KHR_SWAPCHAIN_EXTENSION_NAME );
 }
@@ -148,8 +160,8 @@ void Renderer::_InitDevice()
 	device_create_info.sType					= VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 	device_create_info.queueCreateInfoCount		= 1;
 	device_create_info.pQueueCreateInfos		= &device_queue_create_info;
-	device_create_info.enabledLayerCount		= _device_layers.size();
-	device_create_info.ppEnabledLayerNames		= _device_layers.data();
+//	device_create_info.enabledLayerCount		= _device_layers.size();				// depricated
+//	device_create_info.ppEnabledLayerNames		= _device_layers.data();				// depricated
 	device_create_info.enabledExtensionCount	= _device_extensions.size();
 	device_create_info.ppEnabledExtensionNames	= _device_extensions.data();
 
@@ -232,7 +244,7 @@ void Renderer::_SetupDebug()
 	*/
 	_instance_extensions.push_back( VK_EXT_DEBUG_REPORT_EXTENSION_NAME );
 
-	_device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );
+//	_device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );				// depricated
 	/*
 //	_device_layers.push_back( "VK_LAYER_LUNARG_threading" );
 	_device_layers.push_back( "VK_LAYER_GOOGLE_threading" );

--- a/Tutorial - 0007/Renderer.h
+++ b/Tutorial - 0007/Renderer.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include "Platform.h"
@@ -49,7 +60,7 @@ private:
 
 	std::vector<const char*>				_instance_layers;
 	std::vector<const char*>				_instance_extensions;
-	std::vector<const char*>				_device_layers;
+//	std::vector<const char*>				_device_layers;					// depricated
 	std::vector<const char*>				_device_extensions;
 
 	VkDebugReportCallbackEXT				_debug_report					= VK_NULL_HANDLE;

--- a/Tutorial - 0007/Shared.cpp
+++ b/Tutorial - 0007/Shared.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Shared.h"

--- a/Tutorial - 0007/Shared.h
+++ b/Tutorial - 0007/Shared.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include "Platform.h"

--- a/Tutorial - 0007/Tutorial - 0007.vcxproj
+++ b/Tutorial - 0007/Tutorial - 0007.vcxproj
@@ -69,20 +69,20 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -134,9 +134,11 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="Platform.cpp" />
     <ClCompile Include="Renderer.cpp" />
     <ClCompile Include="Shared.cpp" />
     <ClCompile Include="Window.cpp" />
+    <ClCompile Include="Window_glfw.cpp" />
     <ClCompile Include="Window_win32.cpp" />
     <ClCompile Include="Window_xcb.cpp" />
   </ItemGroup>

--- a/Tutorial - 0007/Tutorial - 0007.vcxproj.filters
+++ b/Tutorial - 0007/Tutorial - 0007.vcxproj.filters
@@ -27,10 +27,16 @@
     <ClCompile Include="Window.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Window_glfw.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Window_win32.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Window_xcb.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Platform.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Tutorial - 0007/Window.cpp
+++ b/Tutorial - 0007/Window.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "Window.h"
 #include "Renderer.h"

--- a/Tutorial - 0007/Window.h
+++ b/Tutorial - 0007/Window.h
@@ -1,3 +1,15 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+Teagan Chouinard (GLFW)
+----------------------------------------------------- */
+
 #pragma once
 
 #include "Platform.h"
@@ -42,7 +54,9 @@ private:
 
 	bool								_window_should_run				= true;
 
-#if VK_USE_PLATFORM_WIN32_KHR
+#if USE_FRAMEWORK_GLFW
+	GLFWwindow						*	_glfw_window					= nullptr;
+#elif VK_USE_PLATFORM_WIN32_KHR
 	HINSTANCE							_win32_instance					= NULL;
 	HWND								_win32_window					= NULL;
 	std::string							_win32_class_name;

--- a/Tutorial - 0007/Window_glfw.cpp
+++ b/Tutorial - 0007/Window_glfw.cpp
@@ -1,0 +1,55 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Teagan Chouinard (GLFW)
+Contributors:
+Niko Kauppi (Code maintenance)
+----------------------------------------------------- */
+
+#include "BUILD_OPTIONS.h"
+#include "Platform.h"
+
+#include "Window.h"
+#include "Shared.h"
+#include "Renderer.h"
+
+#include <assert.h>
+#include <iostream>
+
+#if USE_FRAMEWORK_GLFW
+
+void Window::_InitOSWindow()
+{
+	glfwWindowHint( GLFW_CLIENT_API, GLFW_NO_API );
+	_glfw_window = glfwCreateWindow( _surface_size_x, _surface_size_y, _window_name.c_str(), nullptr, nullptr );
+	glfwGetFramebufferSize( _glfw_window, (int*)&_surface_size_x, (int*)&_surface_size_y );
+}
+
+void Window::_DeInitOSWindow()
+{
+	glfwDestroyWindow( _glfw_window );
+}
+
+void Window::_UpdateOSWindow()
+{
+	glfwPollEvents();
+
+	if( glfwWindowShouldClose( _glfw_window ) ) {
+		Close();
+	}
+}
+
+void Window::_InitOSSurface()
+{
+	if( VK_SUCCESS != glfwCreateWindowSurface( _renderer->GetVulkanInstance(), _glfw_window, nullptr, &_surface ) ) {
+		glfwTerminate();
+		assert( 0 && "GLFW could not create the window surface." );
+		return;
+	}
+}
+
+#endif // USE_FRAMEWORK_GLFW

--- a/Tutorial - 0007/Window_win32.cpp
+++ b/Tutorial - 0007/Window_win32.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Platform.h"

--- a/Tutorial - 0007/Window_xcb.cpp
+++ b/Tutorial - 0007/Window_xcb.cpp
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+hodasemi (XCB validation)
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Platform.h"

--- a/Tutorial - 0007/main.cpp
+++ b/Tutorial - 0007/main.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "Renderer.h"
 

--- a/Tutorial - 0008/BUILD_OPTIONS.h
+++ b/Tutorial - 0008/BUILD_OPTIONS.h
@@ -1,4 +1,21 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #define BUILD_ENABLE_VULKAN_DEBUG								1
 #define BUILD_ENABLE_VULKAN_RUNTIME_DEBUG						1
+
+// To use GLFW, make sure that it's available in the include directories
+// along with library directories. You will also need to add
+// GLFWs "*.lib" file into the project, this task is up to you.
+// GLFW 3.2 is required.
+#define BUILD_USE_GLFW											0

--- a/Tutorial - 0008/Platform.cpp
+++ b/Tutorial - 0008/Platform.cpp
@@ -1,0 +1,71 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Teagan Chouinard (GLFW)
+Contributors:
+Niko Kauppi (Code maintenance)
+----------------------------------------------------- */
+
+#include "Platform.h"
+
+#include <assert.h>
+
+#if USE_FRAMEWORK_GLFW
+
+void InitPlatform()
+{
+	glfwInit();
+	if( glfwVulkanSupported() == GLFW_FALSE ) {
+		assert( 0 && " GLFW Failed to initialize with Vulkan." );
+		return;
+	}
+}
+
+void DeInitPlatform()
+{
+	glfwTerminate();
+}
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions ){
+	uint32_t instance_extension_count = 0;
+	const char ** instance_extensions_buffer = glfwGetRequiredInstanceExtensions( &instance_extension_count );
+	for ( uint32_t i=0; i < instance_extension_count; i++ ){
+		instance_extensions->push_back( instance_extensions_buffer[i] );
+	}
+}
+
+#elif VK_USE_PLATFORM_WIN32_KHR
+
+void InitPlatform()
+{
+}
+
+void DeInitPlatform()
+{
+}
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions )
+{
+	instance_extensions->push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
+}
+
+#elif VK_USE_PLATFORM_XCB_KHR
+
+void InitPlatform()
+{
+}
+
+void DeInitPlatform()
+{
+}
+
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions )
+{
+	instance_extensions->push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
+}
+
+#endif

--- a/Tutorial - 0008/Platform.h
+++ b/Tutorial - 0008/Platform.h
@@ -1,3 +1,15 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+Teagan Chouinard (GLFW)
+----------------------------------------------------- */
+
 #pragma once
 
 // Contact me if you're interested about adding platform
@@ -6,13 +18,33 @@
 // Biggest missing right now is support for Android.
 // others like Xlib and so are also welcome additions.
 
-// WINDOWS
+#include "BUILD_OPTIONS.h"
+#include <stdint.h>
+#include <vector>
+
+void InitPlatform();
+void DeInitPlatform();
+void AddRequiredPlatformInstanceExtensions( std::vector<const char *> *instance_extensions );
+
+// GLFW
+#if BUILD_USE_GLFW
+
+// Define as a build option 
+#define USE_FRAMEWORK_GLFW 1
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+// For Windows Message Box
 #if defined( _WIN32 )
+#undef APIENTRY
+#include <windows.h>
+#endif 
+
+// WINDOWS
+#elif defined( _WIN32 )
 // this is always defined on windows platform
 
 #define VK_USE_PLATFORM_WIN32_KHR 1
-#define PLATFORM_SURFACE_EXTENSION_NAME VK_KHR_WIN32_SURFACE_EXTENSION_NAME
-#include <Windows.h>
+#include <windows.h>
 
 // LINUX ( Via XCB library )
 #elif defined( __linux )
@@ -22,7 +54,6 @@
 // xcb seems like a popular and well supported option on X11, until wayland and mir take over
 
 #define VK_USE_PLATFORM_XCB_KHR 1
-#define PLATFORM_SURFACE_EXTENSION_NAME VK_KHR_XCB_SURFACE_EXTENSION_NAME
 #include <xcb/xcb.h>
 
 #else

--- a/Tutorial - 0008/Renderer.cpp
+++ b/Tutorial - 0008/Renderer.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Platform.h"
@@ -14,6 +24,7 @@
 
 Renderer::Renderer()
 {
+	InitPlatform();
 	_SetupLayersAndExtensions();
 	_SetupDebug();
 	_InitInstance();
@@ -28,6 +39,7 @@ Renderer::~Renderer()
 	_DeInitDevice();
 	_DeInitDebug();
 	_DeInitInstance();
+	DeInitPlatform();
 }
 
 Window * Renderer::OpenWindow( uint32_t size_x, uint32_t size_y, std::string name )
@@ -77,7 +89,7 @@ const VkPhysicalDeviceProperties & Renderer::GetVulkanPhysicalDeviceProperties()
 void Renderer::_SetupLayersAndExtensions()
 {
 	_instance_extensions.push_back( VK_KHR_SURFACE_EXTENSION_NAME );
-	_instance_extensions.push_back( PLATFORM_SURFACE_EXTENSION_NAME );
+	AddRequiredPlatformInstanceExtensions( &_instance_extensions );
 
 	_device_extensions.push_back( VK_KHR_SWAPCHAIN_EXTENSION_NAME );
 }
@@ -148,8 +160,8 @@ void Renderer::_InitDevice()
 	device_create_info.sType					= VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 	device_create_info.queueCreateInfoCount		= 1;
 	device_create_info.pQueueCreateInfos		= &device_queue_create_info;
-	device_create_info.enabledLayerCount		= _device_layers.size();
-	device_create_info.ppEnabledLayerNames		= _device_layers.data();
+//	device_create_info.enabledLayerCount		= _device_layers.size();			// depricated
+//	device_create_info.ppEnabledLayerNames		= _device_layers.data();			// depricated
 	device_create_info.enabledExtensionCount	= _device_extensions.size();
 	device_create_info.ppEnabledExtensionNames	= _device_extensions.data();
 
@@ -232,7 +244,7 @@ void Renderer::_SetupDebug()
 	*/
 	_instance_extensions.push_back( VK_EXT_DEBUG_REPORT_EXTENSION_NAME );
 
-	_device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );
+//	_device_layers.push_back( "VK_LAYER_LUNARG_standard_validation" );			// depricated
 	/*
 //	_device_layers.push_back( "VK_LAYER_LUNARG_threading" );
 	_device_layers.push_back( "VK_LAYER_GOOGLE_threading" );

--- a/Tutorial - 0008/Renderer.h
+++ b/Tutorial - 0008/Renderer.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include "Platform.h"
@@ -49,7 +60,7 @@ private:
 
 	std::vector<const char*>				_instance_layers;
 	std::vector<const char*>				_instance_extensions;
-	std::vector<const char*>				_device_layers;
+//	std::vector<const char*>				_device_layers;					// depricated
 	std::vector<const char*>				_device_extensions;
 
 	VkDebugReportCallbackEXT				_debug_report					= VK_NULL_HANDLE;

--- a/Tutorial - 0008/Shared.cpp
+++ b/Tutorial - 0008/Shared.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Shared.h"

--- a/Tutorial - 0008/Shared.h
+++ b/Tutorial - 0008/Shared.h
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
+
 #pragma once
 
 #include "Platform.h"

--- a/Tutorial - 0008/Tutorial - 0008.vcxproj
+++ b/Tutorial - 0008/Tutorial - 0008.vcxproj
@@ -69,20 +69,20 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin32;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>C:\VulkanSDK\1.0.5.0\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\VulkanSDK\1.0.5.0\Bin;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\VulkanSDK\1.0.13.0\Include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\VulkanSDK\1.0.13.0\Bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -99,6 +99,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>USE_GLFW;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>vulkan-1.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -125,6 +126,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>USE_GLFW;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -134,9 +136,11 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="Platform.cpp" />
     <ClCompile Include="Renderer.cpp" />
     <ClCompile Include="Shared.cpp" />
     <ClCompile Include="Window.cpp" />
+    <ClCompile Include="Window_glfw.cpp" />
     <ClCompile Include="Window_win32.cpp" />
     <ClCompile Include="Window_xcb.cpp" />
   </ItemGroup>

--- a/Tutorial - 0008/Tutorial - 0008.vcxproj.filters
+++ b/Tutorial - 0008/Tutorial - 0008.vcxproj.filters
@@ -27,10 +27,16 @@
     <ClCompile Include="Window.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Window_glfw.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Window_win32.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Window_xcb.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Platform.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Tutorial - 0008/Window.cpp
+++ b/Tutorial - 0008/Window.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "Window.h"
 #include "Renderer.h"

--- a/Tutorial - 0008/Window.h
+++ b/Tutorial - 0008/Window.h
@@ -1,3 +1,15 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+Teagan Chouinard (GLFW)
+----------------------------------------------------- */
+
 #pragma once
 
 #include "Platform.h"
@@ -49,7 +61,9 @@ private:
 
 	bool								_window_should_run				= true;
 
-#if VK_USE_PLATFORM_WIN32_KHR
+#if USE_FRAMEWORK_GLFW
+	GLFWwindow						*	_glfw_window					= nullptr;
+#elif VK_USE_PLATFORM_WIN32_KHR
 	HINSTANCE							_win32_instance					= NULL;
 	HWND								_win32_window					= NULL;
 	std::string							_win32_class_name;

--- a/Tutorial - 0008/Window_glfw.cpp
+++ b/Tutorial - 0008/Window_glfw.cpp
@@ -1,0 +1,55 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Teagan Chouinard (GLFW)
+Contributors:
+Niko Kauppi (Code maintenance)
+----------------------------------------------------- */
+
+#include "BUILD_OPTIONS.h"
+#include "Platform.h"
+
+#include "Window.h"
+#include "Shared.h"
+#include "Renderer.h"
+
+#include <assert.h>
+#include <iostream>
+
+#if USE_FRAMEWORK_GLFW
+
+void Window::_InitOSWindow()
+{	
+	glfwWindowHint( GLFW_CLIENT_API, GLFW_NO_API );
+	_glfw_window = glfwCreateWindow( _surface_size_x, _surface_size_y, _window_name.c_str(), nullptr, nullptr );
+	glfwGetFramebufferSize ( _glfw_window, (int*)&_surface_size_x, (int*)&_surface_size_y );
+}
+
+void Window::_DeInitOSWindow()
+{
+	glfwDestroyWindow( _glfw_window );	
+}
+
+void Window::_UpdateOSWindow()
+{
+	glfwPollEvents();
+
+	if ( glfwWindowShouldClose( _glfw_window ) ){
+		Close();
+	}
+}
+
+void Window::_InitOSSurface()
+{
+	if ( VK_SUCCESS != glfwCreateWindowSurface( _renderer->GetVulkanInstance(), _glfw_window, nullptr, &_surface ) ){
+		glfwTerminate();
+		assert ( 0 && "GLFW could not create the window surface." );
+		return;
+	}
+}
+
+#endif // USE_FRAMEWORK_GLFW

--- a/Tutorial - 0008/Window_win32.cpp
+++ b/Tutorial - 0008/Window_win32.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Platform.h"

--- a/Tutorial - 0008/Window_xcb.cpp
+++ b/Tutorial - 0008/Window_xcb.cpp
@@ -1,3 +1,14 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+hodasemi (XCB validation)
+----------------------------------------------------- */
 
 #include "BUILD_OPTIONS.h"
 #include "Platform.h"

--- a/Tutorial - 0008/main.cpp
+++ b/Tutorial - 0008/main.cpp
@@ -1,3 +1,13 @@
+/* -----------------------------------------------------
+This source code is public domain ( CC0 )
+The code is provided as-is without limitations, requirements and responsibilities.
+Creators and contributors to this source code are provided as a token of appreciation
+and no one associated with this source code can be held responsible for any possible
+damages or losses of any kind.
+
+Original file creator:  Niko Kauppi (Code maintenance)
+Contributors:
+----------------------------------------------------- */
 
 #include "Renderer.h"
 
@@ -5,7 +15,7 @@ int main()
 {
 	Renderer r;
 
-	r.OpenWindow( 800, 600, "Vulkan API Tutorial 7" );
+	r.OpenWindow( 800, 600, "Vulkan API Tutorial 8" );
 
 	while( r.Run() ) {
 


### PR DESCRIPTION
GLFW made available on tutorial 6 and upwards. Updated all tutorials to use Vulkan SDK version 1.0.13.0, commented out depricated code. Added licence text to all files along with per-file contributions list. Lots of small fixes.
